### PR TITLE
Fix F_SETFL: [error](null)[main] on Windows

### DIFF
--- a/src/packet.c
+++ b/src/packet.c
@@ -44,7 +44,7 @@ int create_listen_socket()
 
 #ifdef _WIN32
     unsigned long flags = 1;
-    if (ioctlsocket(listen_sock, FIONBIO, &flags) != SOCKET_ERROR)
+    if (ioctlsocket(listen_sock, FIONBIO, &flags) == SOCKET_ERROR)
 #else
     if (fcntl(listen_sock, F_SETFL, O_NONBLOCK) == -1)
 #endif


### PR DESCRIPTION
Fixes #38. Probably just an oversight since the project doesn't really get tested on Windows often.
Compiled and tested on two machines with a custom server to check if it works properly.